### PR TITLE
fix: qbittorrent probes, postgres dependsOn, dead externalsecrets

### DIFF
--- a/kubernetes/apps/vpn/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/vpn/qbittorrent/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /api/v2/app/version
+                    path: /
                     port: *port
                   initialDelaySeconds: 0
                   periodSeconds: 10


### PR DESCRIPTION
## Summary
- Re-enable qbittorrent's liveness/readiness/startup probes (were disabled), probing the unauthenticated WebUI root (`/`) instead of `/api/v2/app/version` — that API endpoint requires an authenticated session, so the kubelet's probe was getting 403'd. Matches the pattern `nzbget` already uses in the same namespace.
- Add `dependsOn: cloudnative-pg-cluster` (namespace `database`) to the Flux Kustomizations of 15 apps that run a `postgres-init` initContainer (prowlarr, immich, bazarr, seerr, pinepods, dashbrr, autobrr, sonarr, radarr, lidarr, home-assistant, paperless-ngx, manyfold, romm, vikunja), so they wait for the Postgres cluster to be `Ready` instead of racing it on a full rebuild.
- Remove two unused/dead `ExternalSecret` manifests (`default/changedetection`, `media/audiobookshelf`) that were empty or unreferenced and already excluded from their `kustomization.yaml`.

## Test plan
- [ ] `flux diff kustomization` (or equivalent) shows only the intended `dependsOn` additions and probe/file changes
- [ ] Confirm qbittorrent pod passes liveness/readiness checks after rollout
- [ ] Confirm the 15 postgres-dependent Kustomizations reconcile cleanly with the new `dependsOn`


---
_Generated by [Claude Code](https://claude.ai/code/session_01GXU44MR5chPzpHdmrEhHGV)_